### PR TITLE
NO-REF: Remove certificate phase of the plugin

### DIFF
--- a/kong/plugins/tag-executor/handler.lua
+++ b/kong/plugins/tag-executor/handler.lua
@@ -9,7 +9,6 @@ local TagExecutor = {
 }
 
 local PHASES = {
-  certificate   = "certificate",
   rewrite       = "rewrite",
   access        = "access",
   header_filter = "header_filter",
@@ -97,10 +96,6 @@ function TagExecutor:init_worker()
     self.plugins_by_phase[phase] = filter_array_items(target_plugins, build_phase_predicate(phase))
   end
 
-end
-
-function TagExecutor:certificate(config)
-  invoke_plugins_for_phase(PHASES.certificate, self.plugins_by_phase, config.tag_execute_steps, kong.router.get_route())
 end
 
 function TagExecutor:preread(config)


### PR DESCRIPTION
Remove certificate phase as it's not actually possible to `get_route` during this phase, which defeats the purpose of the plugin.