### PR TITLE
Fix behaviour after 3.x.x upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       bumpVersion:
-        decription: |
+        description: |
           Bump to this version after release.
           If left empty will bump revision only
         required: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,21 @@ jobs:
       fail-fast: true
       matrix:
         kongVersion:
-        - "2.7.x"
-        - "2.8.x"
-        - "nightly"
+          - "2.7.x"
+          - "2.8.x"
+          - "3.3.x"
+          - "dev"
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: Kong/kong-pongo-action@v1
-      with:
-        kong_version: ${{ matrix.kongVersion }}
+      - uses: Kong/kong-pongo-action@latest
+        with:
+          kong_version: ${{ matrix.kongVersion }}
 
-    - run: pongo run -- --coverage
+      - run: pongo run -- --coverage
 
-    - uses: leafo/gh-actions-lua@v8
-      if: success()
-    - uses: leafo/gh-actions-luarocks@v4
-      if: success()
+      - uses: leafo/gh-actions-lua@v8
+        if: success()
+      - uses: leafo/gh-actions-luarocks@v4
+        if: success()


### PR DESCRIPTION
Due to changes in 3.x.x version of Kong it's now possible to land inside plugin execution phases without matched Kong route.

This poses a challenge since plugin is looking for specific tags on matched route. 
To avoid this issue it's best to skip execution when no route exists.